### PR TITLE
fix(docs): make jsonrpc required and update discovery endpoint in TypeScript guide

### DIFF
--- a/docs/a2a-typescript-guide.md
+++ b/docs/a2a-typescript-guide.md
@@ -21,7 +21,7 @@ All A2A messages follow the JSON-RPC 2.0 format with the following base structur
 
 ```typescript
 interface JSONRPCMessage {
-  jsonrpc?: "2.0";
+  jsonrpc: "2.0";
   id?: number | string | null;
   method?: string;
   params?: unknown;
@@ -264,7 +264,7 @@ bun run a2a:cli
 $ bun x tsx src/cli.ts
 A2A Terminal Client
 Agent URL: http://localhost:41241
-Attempting to fetch agent card from: http://localhost:41241/.well-known/agent.json
+Attempting to fetch agent card from: http://localhost:41241/.well-known/agent-card.json
 ✓ Agent Card Found:
   Name:        Coder Agent
   Description: An agent that generates code based on natural language instructions and streams file outputs.


### PR DESCRIPTION
## Summary

Two fixes in \`docs/a2a-typescript-guide.md\`:

### 1. \`jsonrpc\` field marked as required (relates to a2aproject/A2A#1369)

The \`JSONRPCMessage\` interface marked \`jsonrpc\` as optional (\`?\`), but the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification) requires it to be present and exactly \`"2.0"\` in every request and response.

\`\`\`diff
- jsonrpc?: "2.0";
+ jsonrpc: "2.0";
\`\`\`

### 2. Discovery endpoint updated to \`agent-card.json\` (relates to a2aproject/A2A#1366)

The sample terminal output showed the v0.2.x discovery path. From v0.3.0 onwards the path changed to \`agent-card.json\`.

\`\`\`diff
- Attempting to fetch agent card from: http://localhost:41241/.well-known/agent.json
+ Attempting to fetch agent card from: http://localhost:41241/.well-known/agent-card.json
\`\`\`

## Related issues

- Closes #15
- a2aproject/A2A#1366 — Discovery endpoint path inconsistency
- a2aproject/A2A#1369 — \`jsonrpc\` field should be required
- Tracked in #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)