### PR TITLE
Add Not Human Search to Tools (agent discovery search engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Essential tools for A2A protocol development, testing, and validation.
 
 **🔗 [A2A Protocol Validator](https://a2aprotocol.ai/a2a-protocol-validator)**
 
+**🔗 [Not Human Search](https://nothumansearch.ai)** — Agent discovery search engine. Indexes 8,000+ agent-readable services ranked across 7 signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). Includes `verify_mcp` live JSON-RPC probe to confirm an advertised agent endpoint is actually reachable. Queryable via REST API, MCP server, or browser. [Source](https://github.com/unitedideas/nothumansearch)
 
 | [Ambr](https://ambr.run) | [OMRA Corp](https://ambr.run) | Production A2A agent for legal contract management. Creates, signs, and verifies dual-format Ricardian Contracts (human-readable + machine-parsable JSON, SHA-256 linked). 6 skills, x402 USDC payments. [Agent Card](https://getamber.dev/.well-known/agent.json) | N/A |
 [⬆️ Back to Contents](#contents)


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) under **Tools**.

Agent-first search engine + discovery directory useful for the A2A ecosystem: indexes 8,000+ agent-readable services (sites that publish llms.txt, OpenAPI, ai-plugin, MCP, or structured APIs). Includes a live `verify_mcp` JSON-RPC probe that confirms an advertised endpoint is actually reachable — useful for any A2A client building a verified directory of counterpart agents.

- Source: https://github.com/unitedideas/nothumansearch (MIT)
- MCP endpoint: https://nothumansearch.ai/mcp
- REST API: https://nothumansearch.ai/api/v1/search
- Official MCP registry: `ai.nothumansearch/search`

NHS doesn't yet parse A2A Agent Card structure specifically — happy to add dedicated Agent Card indexing once the spec stabilizes. For now it already catches any service exposing machine-readable manifests, which covers a lot of A2A-aspiring services.