### PR TITLE
Add AlgoVoi multi-chain A2A payment gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Essential tools for A2A protocol development, testing, and validation.
 **🔗 [Not Human Search](https://nothumansearch.ai)** — Agent discovery search engine. Indexes 8,000+ agent-readable services ranked across 7 signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). Includes `verify_mcp` live JSON-RPC probe to confirm an advertised agent endpoint is actually reachable. Queryable via REST API, MCP server, or browser. [Source](https://github.com/unitedideas/nothumansearch)
 
 | [Ambr](https://ambr.run) | [OMRA Corp](https://ambr.run) | Production A2A agent for legal contract management. Creates, signs, and verifies dual-format Ricardian Contracts (human-readable + machine-parsable JSON, SHA-256 linked). 6 skills, x402 USDC payments. [Agent Card](https://getamber.dev/.well-known/agent.json) | N/A |
+| [AlgoVoi](https://algovoi.co.uk) | [AlgoVoi](https://algovoi.co.uk) | Production multi-chain, multi-protocol A2A payment gateway. Verifies on-chain payments and creates hosted checkout links across 7 chains (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo). Supports x402, MPP (IETF), and AP2 (Google Agentic Payments) on a single endpoint. 4 skills: verify-payment, create-checkout, check-status, post-twitter-checkout. [Agent Card](https://api1.ilovechicken.co.uk/.well-known/agent.json) | N/A |
 [⬆️ Back to Contents](#contents)
 
 


### PR DESCRIPTION
Adding **AlgoVoi** — a production A2A payment gateway live at https://api1.ilovechicken.co.uk.

## What it does

Multi-chain, multi-protocol crypto payment verification agent. Verifies on-chain payments and creates hosted checkout links. Gates resources via x402 HTTP 402, MPP (IETF), or AP2 (Google Agentic Payments) — all on a single endpoint.

## Capabilities

- **7 chains**: Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo
- **3 payment protocols**: x402, MPP, AP2
- **4 A2A skills**: verify-payment, create-checkout, check-status, post-twitter-checkout

## Agent card

https://api1.ilovechicken.co.uk/.well-known/agent.json

Also discoverable at https://algovoi.co.uk/.well-known/agent.json and at alternate paths (agent-card.json, a2a.json, agents.json, ai-plugin.json). A2A-Version 0.3.

Entry placed alongside Ambr in the Tools section, matching the existing row format for production live agents.