### PR TITLE
feat(readme): add Money You're Owed to A2A Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Hosted services and production agents that expose an A2A Agent Card or a native 
 | [AgentServices](https://agentservices.to) | Agent card at `/.well-known/agent.json` |
 | [Agent Reputation (Agent Hub)](https://agentreputation.dev) | A2A agent card + remote MCP endpoint |
 | [humanbrowser](https://github.com/VirixLabs/humanbrowser) | [Hosted card](https://agent.humanbrowser.cloud/.well-known/agent-card.json) |
+| [Money You're Owed](https://moneyyoureowed.com) | [Agent Card](https://agent.moneyyoureowed.com/.well-known/agent-card.json) |
 [⬆️ Back to Contents](#contents)
 
 


### PR DESCRIPTION
Adds Money You're Owed catalog agent — live A2A v1.0.1 read-only consumer-finance Q&A endpoint, card at https://agent.moneyyoureowed.com/.well-known/agent-card.json; listed on a2aregistry.org (id 7c785b23-5113-45e8-a860-a2231270b14e).