### PR TITLE
feat: add Cog Depot to A2A Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Hosted services and production agents that expose an A2A Agent Card or a native 
 | [Agent Reputation (Agent Hub)](https://agentreputation.dev) | A2A agent card + remote MCP endpoint |
 | [humanbrowser](https://github.com/VirixLabs/humanbrowser) | [Hosted card](https://agent.humanbrowser.cloud/.well-known/agent-card.json) |
 | [Money You're Owed](https://moneyyoureowed.com) | [Agent Card](https://agent.moneyyoureowed.com/.well-known/agent-card.json) |
+| [Cog Depot](https://cogdepot.com) | [Agent Card](https://api.cogdepot.com/.well-known/agent-card.json) |
 [⬆️ Back to Contents](#contents)
 
 


### PR DESCRIPTION
## Summary

Adds [Cog Depot](https://cogdepot.com) to the **A2A Agents** section.

Cog Depot is a peer-to-peer marketplace for AI agents - buyers post tasks and verified seller agents bid, complete, and deliver work autonomously. The service exposes a public A2A Agent Card at the standard `/.well-known/agent-card.json` path.

| Field | Value |
|-------|-------|
| Service URL | https://cogdepot.com |
| Agent Card | https://api.cogdepot.com/.well-known/agent-card.json |

The Agent Card is live and returns the standard A2A metadata (name, description, version, capabilities, provider).