### PR TITLE
feat(agents): add IdeaTrace AI — first Chinese-market creator agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A2A (Agent2Agent) is an open protocol from Google enabling AI agents to communic
 
 | Project Name | Description | Link |
 |-------------|-------------|------|
+| [IdeaTrace AI](https://ideatrace-a2a-server.vercel.app) | [@ideatrace](https://tiny.place/@ideatrace) | First Chinese-market creator agent: short-video scripts, AI skill library, monetization research. Full Web4 stack (ERC-8004 identity + tiny.place + x402 mainnet USDC). Arbitrage recommendation engine WIP. [Agent Card](https://gist.githubusercontent.com/urbanlifeenjoy-code/21c5e75e9bf738a08051577def2d31da/raw/agent-card.json) |
 | Google ADK | Expense report filling agent, showcasing multi-turn interactions and web form handling | [google_adk](https://github.com/google-a2a/a2a-samples/tree/main/samples/python/agents/google_adk) |
 | AG2 + MCP | MCP-enabled agent based on AG2 framework | [ag2](https://github.com/google-a2a/a2a-samples/tree/main/samples/python/agents/ag2) |
 | Azure AI Foundry | Agent based on Azure AI Foundry services | [azureaifoundry_sdk](https://github.com/google-a2a/a2a-samples/tree/main/samples/python/agents/azureaifoundry_sdk) |


### PR DESCRIPTION
Add IdeaTrace AI — the first **Chinese-creator-vertical** A2A agent in the directory.

## Why it's different
- 12 existing agents are dev/legal/privacy/payment oriented (all English). IdeaTrace is the first targeting **Chinese short-video creators & AI tool users** (a market of hundreds of millions).
- Full Web4 stack: ERC-8004 on-chain identity (Solana devnet) + tiny.place social identity (@ideatrace, mainnet) + x402 USDC micropayments.
- Backed by 爱迪创思 IdeaTrace knowledge base (7208+ curated AI skills).

## Agent Card
- **English (A2A standard):** https://gist.githubusercontent.com/urbanlifeenjoy-code/f751155ddaa8048bf992a131cbe40654/raw/agent-card-en.json
- Hosted at: https://ideatrace-a2a-server.vercel.app
- Brand: 爱迪创思 IdeaTrace (ideatrace.cn, ICP-filing in progress, China-facing content site)

## Skills
- idea-tracing / skill-library / script-writing / monetization-research

## Verification
- A2A JSON-RPC 2.0 + x402 payment middleware: tested locally (402 without payment, 200 with payment)
- Agent Card discovery: ✅
- x402 discovery manifest: ✅

> Note: directory entry is English/standard for agent discovery; the human-facing site ideatrace.cn is Chinese (ICP filing). Both under same brand 爱迪创思 IdeaTrace.